### PR TITLE
home-assistant: Volume claim templates should not include version labels

### DIFF
--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: home-assistant
-version: 1.1.0
+version: 1.1.1

--- a/charts/home-assistant/templates/statefulset.yaml
+++ b/charts/home-assistant/templates/statefulset.yaml
@@ -68,7 +68,7 @@ spec:
       metadata:
         name: config
         labels:
-          {{- include "common.labels" . | nindent 10 }}
+          {{- include "common.selectorLabels" . | nindent 10 }}
           {{ if .Values.persistence.labels }}
           {{ toYaml .Values.persistence.labels | nindent 10 }}
           {{ end }}


### PR DESCRIPTION
Volume claim template may not be updated so it should not contain version labels

![image](https://github.com/user-attachments/assets/a30f77f5-dd70-4161-ad1f-3f92b2ec22cf)
