### PR TITLE
immich: Add startup probe to give immich time to perform geodata import, db migrations and filesystem checks

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: immich
-version: 2.5.0
+version: 2.6.0
 
 home: https://immich.app
 sources:

--- a/charts/immich/templates/machine-learning/deployment.yaml
+++ b/charts/immich/templates/machine-learning/deployment.yaml
@@ -35,18 +35,10 @@ spec:
             - name: TRANSFORMERS_CACHE
               value: /cache
           livenessProbe:
-            initialDelaySeconds: 0
-            timeoutSeconds: 1
-            periodSeconds: 10
-            failureThreshold: 3
             httpGet:
               port: http
               path: /ping
           readinessProbe:
-            initialDelaySeconds: 0
-            timeoutSeconds: 1
-            periodSeconds: 10
-            failureThreshold: 3
             httpGet:
               port: http
               path: /ping

--- a/charts/immich/templates/server/deployment.yaml
+++ b/charts/immich/templates/server/deployment.yaml
@@ -61,19 +61,17 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.database.clusterName }}-app
                   key: password
-          livenessProbe:
-            initialDelaySeconds: 0
-            timeoutSeconds: 1
+          startupProbe:
             periodSeconds: 10
-            failureThreshold: 3
+            failureThreshold: 60
+            httpGet:
+              port: http
+              path: /api/server/ping
+          livenessProbe:
             httpGet:
               port: http
               path: /api/server/ping
           readinessProbe:
-            initialDelaySeconds: 0
-            timeoutSeconds: 1
-            periodSeconds: 10
-            failureThreshold: 3
             httpGet:
               port: http
               path: /api/server/ping


### PR DESCRIPTION
Fixes for example the following longer running startup job:

``` 
[Nest] 17  - 10/15/2024, **6:47:29** PM     LOG [Api:EventRepository] Initialized websocket server
[Nest] 7  - 10/15/2024, **6:48:31** PM     LOG [Microservices:MapRepository] Geodata import completed
```