### PR TITLE
BREAKING CHANGE: Immich migrate vectorchord

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: immich
-version: 4.1.0
+version: 5.0.0
 
 home: https://immich.app
 sources:

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: immich
-version: 4.0.0
+version: 4.1.0
 
 home: https://immich.app
 sources:

--- a/charts/immich/templates/database/database.yaml
+++ b/charts/immich/templates/database/database.yaml
@@ -9,22 +9,19 @@ spec:
   instances: {{ .Values.database.replicas }}
   imageName: {{ .Values.database.image.registry }}/{{ .Values.database.image.repository }}:{{ .Values.database.image.tag }}
 
+  extensions:
+  - name: vectors
+    ensure: absent
+  - name: vchord
+    ensure: present
+  - name: earthdistance
+    ensure: present
+
   postgresql:
     shared_preload_libraries:
-      - "vectors.so"
+      - 'vchord.so'
 
   logLevel: {{ .Values.database.logLevel }}
-
-  bootstrap:
-    initdb:
-      postInitApplicationSQL:
-        - CREATE EXTENSION IF NOT EXISTS "vectors";
-        - CREATE EXTENSION IF NOT EXISTS "cube";
-        - CREATE EXTENSION IF NOT EXISTS "earthdistance";
-        - ALTER SYSTEM SET search_path TO app, public, vectors;
-        - ALTER SCHEMA vectors OWNER TO app;
-        # run this via kubectl exec in database pod after the schema is created
-        #- \c app; GRANT SELECT ON TABLE pg_vector_index_stat TO app;
 
   storage:
     size: {{ .Values.database.size }}

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -75,7 +75,7 @@ server:
   image:
     registry: ghcr.io
     repository: immich-app/immich-server
-    tag: v1.132.3
+    tag: v1.133.1
     pullPolicy: IfNotPresent
   podSecurityContext: {}
 

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -56,7 +56,7 @@ machineLearning:
   image:
     registry: ghcr.io
     repository: immich-app/immich-machine-learning
-    tag: v1.132.3
+    tag: v1.133.1
     pullPolicy: IfNotPresent
   
   modelPreload:

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -30,8 +30,8 @@ ingress:
 database:
   image:
     registry: ghcr.io
-    repository: tensorchord/cloudnative-pgvecto.rs
-    tag: 16.3-v0.2.1
+    repository: ghcr.io/tensorchord/cloudnative-vectorchord
+    tag: 16-0.4.0
 
   clusterName: immich-postgresql
   logLevel: error


### PR DESCRIPTION
Before upgrading to this version perform the following steps:

1. Update to 4.1.0
2. Turn off immich
3. Run the **manual** migration steps from https://immich.app/docs/administration/postgres-standalone/#migrating-from-pgvectors
4. Update to 5.0.0
5. Turn on immich
