### PR TITLE
[dawarich] Support specifying database download uri

### DIFF
--- a/charts/dawarich/Chart.yaml
+++ b/charts/dawarich/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dawarich
-version: 11.0.0
+version: 11.1.0
 kubeVersion: ">=1.19.0-0"
 
 home: https://dawarich.app/

--- a/charts/dawarich/templates/photon/statefulset.yaml
+++ b/charts/dawarich/templates/photon/statefulset.yaml
@@ -25,6 +25,10 @@ spec:
         image: '{{ .Values.photon.image.registry }}/{{ .Values.photon.image.repository }}:{{ .Values.photon.image.tag }}'
         imagePullPolicy: {{ .Values.photon.image.pullPolicy }}
         env:
+        {{- with .Values.photon.config.fileUrl }}
+        - name: FILE_URL
+          value: {{ . | quote }}
+        {{- end }}
         {{- with (.Values.photon.config.country | default .Values.photon.config.region) }}
         - name: REGION
           value: {{ . }}

--- a/charts/dawarich/values.yaml
+++ b/charts/dawarich/values.yaml
@@ -93,7 +93,9 @@ photon:
   enabled: true  # Controls whether to use photon at all
   deploy: true   # Controls whether to deploy internal photon instance
   config:
+    fileUrl: # If provided country, region are ignored
     country: # NL, BE, DE, FR, UK, US
+    region: # same as country
     logLevel: INFO # DEBUG, INFO, ERROR
     updateStrategy: PARALLEL # PARALLEL, SEQUENTIAL, DISABLED
     updateInterval: '168h' # Has to be a time string (60s, 60h)


### PR DESCRIPTION
<!--
All pull requests must start with: [product-name]
Example: [home-assistant] Add MQTT configuration
-->

## Summary
Add FILE_URL support for photon so we can test reverse-geocoding only database. See: https://github.com/komoot/photon/pull/1022

## Checklist
- [ ] PR title starts with `[product-name]`
- [ ] Ran `helm lint` and `helm template --validate`
- [ ] Updated `values.yaml` if new values were added
