### PR TITLE
[dawarich] Support reverse only mode for photon with planet database

### DIFF
--- a/charts/dawarich/Chart.yaml
+++ b/charts/dawarich/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dawarich
-version: 12.2.1
+version: 12.3.0
 kubeVersion: ">=1.19.0-0"
 
 home: https://dawarich.app/

--- a/charts/dawarich/templates/photon/statefulset.yaml
+++ b/charts/dawarich/templates/photon/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
         - name: REVERSE_ONLY
           value: "TRUE"
         - name: LANGUAGES
-          value: "en,nl,se"
+          value: {{ .Values.photon.config.languages | join "," }}
         {{- else }}
         {{- with (.Values.photon.config.country | default .Values.photon.config.region) }}
         - name: REGION

--- a/charts/dawarich/templates/photon/statefulset.yaml
+++ b/charts/dawarich/templates/photon/statefulset.yaml
@@ -22,12 +22,26 @@ spec:
         image: '{{ .Values.photon.image.registry }}/{{ .Values.photon.image.repository }}:{{ .Values.photon.image.tag }}'
         imagePullPolicy: {{ .Values.photon.image.pullPolicy }}
         env:
+        - name: LOG_LEVEL
+          value: {{ .Values.photon.config.logLevel }}
+        {{- if .Values.photon.config.reverseOnly }}
+        - name: REGION
+          value: planet
+        - name: IMPORT_MODE
+          value: jsonl
+        - name: REVERSE_ONLY
+          value: "TRUE"
+        - name: LANGUAGES
+          value: "en,nl,se"
+        {{- else }}
         {{- with (.Values.photon.config.country | default .Values.photon.config.region) }}
         - name: REGION
           value: {{ . }}
         {{- end }}
-        - name: LOG_LEVEL
-          value: {{ .Values.photon.config.logLevel }}
+        - name: LANGUAGES
+          value: {{ .Values.photon.config.languages }}
+        - name: IMPORT_MODE
+          value: {{ .Values.photon.config.importMode }}
         - name: UPDATE_STRATEGY
           value: {{ .Values.photon.config.updateStrategy }}
         - name: UPDATE_INTERVAL
@@ -36,6 +50,7 @@ spec:
           value: {{ .Values.photon.config.forceUpdate | quote }}
         - name: SKIP_MD5_CHECK
           value: {{ not .Values.photon.config.md5Check | quote }}
+        {{- end }}
         startupProbe:
           httpGet:
             path: /status

--- a/charts/dawarich/templates/photon/statefulset.yaml
+++ b/charts/dawarich/templates/photon/statefulset.yaml
@@ -38,10 +38,6 @@ spec:
         - name: REGION
           value: {{ . }}
         {{- end }}
-        - name: LANGUAGES
-          value: {{ .Values.photon.config.languages }}
-        - name: IMPORT_MODE
-          value: {{ .Values.photon.config.importMode }}
         - name: UPDATE_STRATEGY
           value: {{ .Values.photon.config.updateStrategy }}
         - name: UPDATE_INTERVAL

--- a/charts/dawarich/values.yaml
+++ b/charts/dawarich/values.yaml
@@ -94,9 +94,15 @@ photon:
   enabled: true  # Controls whether to use photon at all
   deploy: true   # Controls whether to deploy internal photon instance
   config:
-    reverseOnly: true
-    country: # NL, BE, DE, FR, UK, US
     logLevel: INFO # DEBUG, INFO, ERROR
+    reverseOnly: false
+    country: # NL, BE, DE, FR, UK, US, planet
+    # only valid in reverseOnly mode
+    languages:
+    - en
+    # - nl
+    # - se
+    # only valid with reverseOnly disabled
     updateStrategy: PARALLEL # PARALLEL, SEQUENTIAL, DISABLED
     updateInterval: '168h' # Has to be a time string (60s, 60h)
     md5Check: true

--- a/charts/dawarich/values.yaml
+++ b/charts/dawarich/values.yaml
@@ -94,6 +94,7 @@ photon:
   enabled: true  # Controls whether to use photon at all
   deploy: true   # Controls whether to deploy internal photon instance
   config:
+    reverseOnly: true
     country: # NL, BE, DE, FR, UK, US
     logLevel: INFO # DEBUG, INFO, ERROR
     updateStrategy: PARALLEL # PARALLEL, SEQUENTIAL, DISABLED


### PR DESCRIPTION
<!--
All pull requests must start with: [product-name]
Example: [home-assistant] Add MQTT configuration
-->

## Summary
Add support for reverse only database import in photon

<img width="1530" height="796" alt="image" src="https://github.com/user-attachments/assets/37b10bfa-2a7a-4e0c-acbd-8f6dc87af84b" />

Import took about 11 hours with 2 cpu and 6-10GB RAM available. Max used space during import was 60GiB. Final space is about 32GiB.

Database update is not yet supported in photon-docker.